### PR TITLE
arduino.h -> Arduino.h for compilation on case-sensitive filesystems

### DIFF
--- a/firmware/q8bot_robot/include/systemParams.h
+++ b/firmware/q8bot_robot/include/systemParams.h
@@ -1,4 +1,4 @@
-#include <arduino.h>
+#include <Arduino.h>
 
 // ESP-NOW Messaging Types
 enum MsgType : uint8_t{

--- a/firmware/q8bot_robot/include/userParams.h
+++ b/firmware/q8bot_robot/include/userParams.h
@@ -1,4 +1,4 @@
-#include <arduino.h>
+#include <Arduino.h>
 
 // Change this to your controller's MAC address if doing bi-directional ESPNow
 uint8_t receiver_mac[] = {0xEC, 0xDA, 0x3B, 0x38, 0x0C, 0x1C};


### PR DESCRIPTION
Fix compilation on case-sensitive filesystems by changing include from `arduino.h` to `Arduino.h`. This will have no effect on case-insensitive filesystems.